### PR TITLE
Add syntax highlighting for LowerCase and Uppercase tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # WebDNA Language Extension for VSCode Changelog
 
+## Unreleased:
+- Added/updated support for the highlighting of:
+    * Contexts: lowercase, uppercase
+    * Support parameters for tags: lowercase, uppercase (charset)
+
 ## (03/20/2022) v-0.1.2:
 - Updated Readme Information
 - Added/updated support for the highlighting of:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased:
 - Added/updated support for the highlighting of:
-    * Contexts: lowercase, uppercase
-    * Support parameters for tags: lowercase, uppercase (charset)
+    * Contexts: getchars, lowercase, uppercase
+    * Support parameters for tags: getchars (start, end), lowercase, uppercase (charset)
 
 ## (03/20/2022) v-0.1.2:
 - Updated Readme Information

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Syntax Highlighting for WebDNA consists of a few components that each tag has: t
 | ListWords             | ✓        | ✓        | ✓        |
 | Lookup                | ✓        | ✗        | N/A       |
 | Loop                  | ✗        | ✗        | ✗        |
-| LowerCase             | ✗        | ✗        | ✗        |
+| LowerCase             | ✓        | ✓        | ✓        |
 | Math                  | ✓        | ✓        | ✗        |
 | Middle                | ✗        | ✗        | ✗        |
 | MoveFile              | ✓        | ✓        | N/A       |
@@ -173,7 +173,7 @@ Syntax Highlighting for WebDNA consists of a few components that each tag has: t
 | Time                  | ✓        | ✓        | N/A      |
 | UnURL                 | ✓        | N/A       | ✓        |
 | URL                   | ✓        | N/A       | ✓        |
-| Uppercase             | ✗        | ✗        | ✗        |
+| Uppercase             | ✓        | ✓        | ✓        |
 | UserName              | ✓        | N/A       | N/A      |
 | ValidCard             | ✓        | ✓        | N/A      |
 | Version               | ✓        | N/A       | N/A      |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Syntax Highlighting for WebDNA consists of a few components that each tag has: t
 | FoundItems            | ✗        | ✗        | ✗        |
 | FreeMemory            | ✓        | N/A       | N/A      |
 | Function              | ✓        | ✓        | ✗        |
-| GetChars              | ✗        | ✗        | ✗        |
+| GetChars              | ✓        | ✓        | ✓        |
 | GetCookie             | ✓        | ✓        | N/A      |
 | GetMIMEHeader         | ✓        | ✓        | N/A      |
 | Grep                  | ✗        | ✗        | ✗        |

--- a/syntaxes/webdna.tmLanguage.json
+++ b/syntaxes/webdna.tmLanguage.json
@@ -2809,6 +2809,184 @@
 						}]
 					}]
 				}]
+			},{
+				"comment": "WebDNA LowerCase Context",
+				"begin": "(^[ \\t]+)?(?=\\[(?i:lowercase)\\b(?!-))",
+				"beginCaptures": {
+					"1": {
+						"name": "punctuation.whitespace.embedded.leading.webdna"
+					}
+				},
+				"end": "(?!\\G)([ \\t]*$\\n?)?",
+				"endCaptures": {
+					"1": {
+						"name": "punctuation.whitespace.embedded.trailing.webdna"
+					}
+				},
+				"patterns": [{
+					"begin": "(\\[)((?i:lowercase))\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.lowercase.start.webdna"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.webdna"
+						},
+						"2": {
+							"name": "entity.name.tag.webdna"
+						}
+					},
+					"end": "(/)((?i:lowercase))(\\])",
+					"endCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.lowercase.end.webdna"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.webdna"
+						},
+						"2": {
+							"name": "entity.name.tag.webdna"
+						},
+						"3": {
+							"name": "punctuation.definition.tag.end.webdna"
+						}
+					},
+					"patterns": [{
+						"begin": "\\G",
+						"end": "(?=/)",
+						"patterns": [{
+							"begin": "(\\s|&)(?i:(charset))(?![\\w:-])",
+							"beginCaptures": {
+								"1": {
+									"name": "variable.parameter.and.webdna"
+								},
+								"2": {
+									"name": "variable.parameter.webdna"
+								}
+							},
+							"comment": "WebDNA parameters",
+							"end": "(?=\\s*+[^=\\s])",
+							"name": "meta.parameter.$2.webdna",
+							"patterns": [
+								{ "include": "#parameter-interior" }
+							]
+						},{
+							"include": "#webdna"
+						},{
+							"begin": "(\\])",
+							"name": "meta.embedded.context.lowercase.webdna",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.tag.metadata.lowercase.start.webdna"
+								},
+								"1": {
+									"name": "punctuation.definition.tag.end.webdna"
+								}
+							},
+							"end": "((\\[))(?=/(?i:lowercase))",
+							"endCaptures": {
+								"0": {
+									"name": "meta.tag.metadata.lowercase.end.webdna"
+								},
+								"1": {
+									"name": "punctuation.definition.tag.begin.webdna"
+								}
+							},
+							"patterns": [{
+								"include": "#webdna"
+							}]
+						}]
+					}]
+				}]
+			},{
+				"comment": "WebDNA Uppercase Context",
+				"begin": "(^[ \\t]+)?(?=\\[(?i:uppercase)\\b(?!-))",
+				"beginCaptures": {
+					"1": {
+						"name": "punctuation.whitespace.embedded.leading.webdna"
+					}
+				},
+				"end": "(?!\\G)([ \\t]*$\\n?)?",
+				"endCaptures": {
+					"1": {
+						"name": "punctuation.whitespace.embedded.trailing.webdna"
+					}
+				},
+				"patterns": [{
+					"begin": "(\\[)((?i:uppercase))\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.uppercase.start.webdna"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.webdna"
+						},
+						"2": {
+							"name": "entity.name.tag.webdna"
+						}
+					},
+					"end": "(/)((?i:uppercase))(\\])",
+					"endCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.uppercase.end.webdna"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.webdna"
+						},
+						"2": {
+							"name": "entity.name.tag.webdna"
+						},
+						"3": {
+							"name": "punctuation.definition.tag.end.webdna"
+						}
+					},
+					"patterns": [{
+						"begin": "\\G",
+						"end": "(?=/)",
+						"patterns": [{
+							"begin": "(\\s|&)(?i:(charset))(?![\\w:-])",
+							"beginCaptures": {
+								"1": {
+									"name": "variable.parameter.and.webdna"
+								},
+								"2": {
+									"name": "variable.parameter.webdna"
+								}
+							},
+							"comment": "WebDNA parameters",
+							"end": "(?=\\s*+[^=\\s])",
+							"name": "meta.parameter.$2.webdna",
+							"patterns": [
+								{ "include": "#parameter-interior" }
+							]
+						},{
+							"include": "#webdna"
+						},{
+							"begin": "(\\])",
+							"name": "meta.embedded.context.uppercase.webdna",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.tag.metadata.uppercase.start.webdna"
+								},
+								"1": {
+									"name": "punctuation.definition.tag.end.webdna"
+								}
+							},
+							"end": "((\\[))(?=/(?i:uppercase))",
+							"endCaptures": {
+								"0": {
+									"name": "meta.tag.metadata.uppercase.end.webdna"
+								},
+								"1": {
+									"name": "punctuation.definition.tag.begin.webdna"
+								}
+							},
+							"patterns": [{
+								"include": "#webdna"
+							}]
+						}]
+					}]
+				}]
 			}]
 		},
 		"keywords-valid": {

--- a/syntaxes/webdna.tmLanguage.json
+++ b/syntaxes/webdna.tmLanguage.json
@@ -1847,6 +1847,95 @@
 					}]
 				}]
 			},{
+				"comment": "WebDNA GetChars Context",
+				"begin": "(^[ \\t]+)?(?=\\[(?i:getchars)\\b(?!-))",
+				"beginCaptures": {
+					"1": {
+						"name": "punctuation.whitespace.embedded.leading.webdna"
+					}
+				},
+				"end": "(?!\\G)([ \\t]*$\\n?)?",
+				"endCaptures": {
+					"1": {
+						"name": "punctuation.whitespace.embedded.trailing.webdna"
+					}
+				},
+				"patterns": [{
+					"begin": "(\\[)((?i:getchars))\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.getchars.start.webdna"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.webdna"
+						},
+						"2": {
+							"name": "entity.name.tag.webdna"
+						}
+					},
+					"end": "(/)((?i:getchars))(\\])",
+					"endCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.getchars.end.webdna"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.webdna"
+						},
+						"2": {
+							"name": "entity.name.tag.webdna"
+						},
+						"3": {
+							"name": "punctuation.definition.tag.end.webdna"
+						}
+					},
+					"patterns": [{
+						"begin": "\\G",
+						"end": "(?=/)",
+						"patterns": [{
+							"begin": "(\\s|&)(?i:(start|end))(?![\\w:-])",
+							"beginCaptures": {
+								"1": {
+									"name": "variable.parameter.and.webdna"
+								},
+								"2": {
+									"name": "variable.parameter.webdna"
+								}
+							},
+							"comment": "WebDNA parameters",
+							"end": "(?=\\s*+[^=\\s])",
+							"name": "meta.parameter.$2.webdna",
+							"patterns": [
+								{ "include": "#parameter-interior" }
+							]
+						},{
+							"include": "#webdna"
+						},{
+							"begin": "(\\])",
+							"name": "meta.embedded.context.getchars.webdna",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.tag.metadata.getchars.start.webdna"
+								},
+								"1": {
+									"name": "punctuation.definition.tag.end.webdna"
+								}
+							},
+							"end": "((\\[))(?=/(?i:getchars))",
+							"endCaptures": {
+								"0": {
+									"name": "meta.tag.metadata.getchars.end.webdna"
+								},
+								"1": {
+									"name": "punctuation.definition.tag.begin.webdna"
+								}
+							},
+							"patterns": [{
+								"include": "#webdna"
+							}]
+						}]
+					}]
+				}]
+			},{
 				"comment": "WebDNA ListChars Context",
 				"begin": "(^[ \\t]+)?(?=\\[(?i:listchars)\\b(?!-))",
 				"beginCaptures": {


### PR DESCRIPTION
Implements the WebDNA LowerCase and Uppercase context tags following the
same grammar pattern as Capitalize/ConvertChars, including recognition of
the charset parameter used in tests.dna.

https://claude.ai/code/session_01Uiu3ecxiYnwNuwAnKACCtE