### PR TITLE
Add [grep] context to grammar

### DIFF
--- a/syntaxes/webdna.tmLanguage.json
+++ b/syntaxes/webdna.tmLanguage.json
@@ -64,6 +64,95 @@
 
 		"contexts-valid": {
 			"patterns": [{
+				"comment": "WebDNA Grep Context",
+				"begin": "(^[ \\t]+)?(?=\\[(?i:grep)\\b(?!-))",
+				"beginCaptures": {
+					"1": {
+						"name": "punctuation.whitespace.embedded.leading.webdna"
+					}
+				},
+				"end": "(?!\\G)([ \\t]*$\\n?)?",
+				"endCaptures": {
+					"1": {
+						"name": "punctuation.whitespace.embedded.trailing.webdna"
+					}
+				},
+				"patterns": [{
+					"begin": "(\\[)((?i:grep))\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.grep.start.webdna"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.webdna"
+						},
+						"2": {
+							"name": "entity.name.tag.webdna"
+						}
+					},
+					"end": "(/)((?i:grep))(\\])",
+					"endCaptures": {
+						"0": {
+							"name": "meta.tag.metadata.grep.end.webdna"
+						},
+						"1": {
+							"name": "punctuation.definition.tag.begin.webdna"
+						},
+						"2": {
+							"name": "entity.name.tag.webdna"
+						},
+						"3": {
+							"name": "punctuation.definition.tag.end.webdna"
+						}
+					},
+					"patterns": [{
+						"begin": "\\G",
+						"end": "(?=/)",
+						"patterns": [{
+							"begin": "(\\s|&)(?i:(search|replace))(?![\\w:-])",
+							"beginCaptures": {
+								"1": {
+									"name": "variable.parameter.and.webdna"
+								},
+								"2": {
+									"name": "variable.parameter.webdna"
+								}
+							},
+							"comment": "WebDNA parameters",
+							"end": "(?=\\s*+[^=\\s])",
+							"name": "meta.parameter.$2.webdna",
+							"patterns": [
+								{ "include": "#parameter-interior" }
+							]
+						},{
+							"include": "#webdna"
+						},{
+							"begin": "(\\])",
+							"name": "meta.embedded.context.grep.webdna",
+							"beginCaptures": {
+								"0": {
+									"name": "meta.tag.metadata.grep.start.webdna"
+								},
+								"1": {
+									"name": "punctuation.definition.tag.end.webdna"
+								}
+							},
+							"end": "((\\[))(?=/(?i:grep))",
+							"endCaptures": {
+								"0": {
+									"name": "meta.tag.metadata.grep.end.webdna"
+								},
+								"1": {
+									"name": "punctuation.definition.tag.begin.webdna"
+								}
+							},
+							"patterns": [{
+								"include": "#webdna"
+							}]
+						}]
+					}]
+				}]
+			},{
 				"comment": "WebDNA AppendFile Context",
 				"begin": "(^[ \\t]+)?(?=\\[(?i:appendfile)\\b(?!-))",
 				"beginCaptures": {

--- a/tests/tests.dna
+++ b/tests/tests.dna
@@ -334,6 +334,12 @@ else return "it's less that 50!"[/AppleScript]
 [!] ==== [/!]
 [!] Grep [/!]
 [!] ==== [/!]
+[grep search=Mozilla][browsername][/grep]
+[grep search=[0-9]+]There are 42 apples and 7 oranges[/grep]
+[grep search=([^0-9])&replace=][interpret][meetREPPINGCATS[index]][/interpret][/grep]
+
+[!] This Should Not Highlight As They Are Outside the Context! [/!]
+[search]
 
 [!] ==== [/!]
 [!] Hide [/!]


### PR DESCRIPTION
## What
Adds a dedicated `[grep]` context to the WebDNA TextMate grammar.

## Why
`[grep]` was missing from the grammar entirely, so it only matched the generic catch-all tag pattern and received no proper context highlighting — the `search`/`replace` parameters, body, and closing `[/grep]` were not recognized.

## How
- Added a "WebDNA Grep Context" block to `#contexts-valid`, modeled on the existing `Capitalize` context, supporting the `search` and `replace` parameters.
- Added `[grep]` examples (including the `search`/`replace` form) to `tests/tests.dna`.

Verified in the Extension Development Host: tag name, both parameters, body, and closing tag all highlight correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)